### PR TITLE
🐛 Update the clipboard paste handler to handle single word pasting.

### DIFF
--- a/verkaufsanalyse/clipboard.js
+++ b/verkaufsanalyse/clipboard.js
@@ -11,7 +11,15 @@ function initializeClipboard($table, { formatGermanNumber, parseGermanNumber, fo
         let values = clipboardData.split(/[\t]+/);
         values = values.map(val => val.trim());
         
-        if (values.length >= 7) {
+        if (values.length === 1) {
+            // Handle single word paste
+            let cellIndex = $(this).index();
+            if (isEditing) {
+                row.find(`td:nth-child(${cellIndex + 1}) input`).val(values[0]);
+            } else {
+                $(this).text(values[0]);
+            }
+        } else if (values.length >= 7) {
             // If row is in edit mode, update input values instead of text
             if (isEditing) {
                 row.find('td:nth-child(2) input').val(values[0]); // SAP

--- a/verkaufsanalyse/verkaufsanalyse.html
+++ b/verkaufsanalyse/verkaufsanalyse.html
@@ -79,7 +79,7 @@
                     <th>Stück</th>
                     <th>EK á Stück</th>
                     <th>Netto á Stück</th>
-                    <th>Spanne</th>
+                    <th>Marge</th>
                     <th>Brutto á Stück</th>
                     <th>Verkauft (Stück)</th>
                     <th>Schwund (Stück)</th>


### PR DESCRIPTION
Update the clipboard paste handler to handle single word pasting.

Closes #10

## Summary by Sourcery

Enable single-word pasting into table cells. Rename the "Spanne" column header to "Marge".

Enhancements:
- Enable pasting single words into table cells, in addition to the existing multi-value paste functionality.
- Change the "Spanne" column header to "Marge".