### PR TITLE
Preserve materials list state after updates

### DIFF
--- a/lagerbestand/CHANGELOG.md
+++ b/lagerbestand/CHANGELOG.md
@@ -32,7 +32,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated bulk edit/delete operations to preserve state
   - Updated group deletion to preserve state
   - Improved user experience: workflow continuity maintained when managing multiple materials
-  - Files modified: `js/tab-materials.js`, `js/ui-manager.js`
+  - Files modified: `js/tab-materials.js`, `js/ui-manager.js`, `css/tables.css`, `js/utils.js`
+
+### Improved
+
+#### Code Quality & Browser Compatibility
+- **Event-Driven State Restoration**: Replaced arbitrary timeouts with DataTable's draw event
+  - Uses `table.on('draw.stateRestore')` for reliable DOM update detection
+  - Eliminates race conditions from setTimeout-based approaches
+  - Namespaced event handler ensures single execution and proper cleanup
+  
+- **Performance Optimization**: Streamlined DataTable rendering
+  - Combined search, order, and page settings before single `table.draw(false)` call
+  - Reduced from 2 draw calls to 1, minimizing flicker and improving performance
+  - More efficient state application with less DOM manipulation
+  
+- **CSS Class-Based Highlighting**: Replaced inline styles with CSS class
+  - Added `.highlighted-row` class in `css/tables.css`
+  - Proper dark mode support with themed colors
+  - Better maintainability and separation of concerns
+  - No style conflicts with existing CSS rules
+  
+- **Selection Filtering**: Enhanced checkbox state restoration
+  - Filters `selectedMaterials` to only include items present in current table data
+  - Prevents errors when materials have been deleted or data has changed
+  - Validates against current material codes before restoring selection
+  - More robust handling of edge cases
+  
+- **Type Safety**: Added parameter validation for `renderMaterialsList()`
+  - Type check ensures `options` is an object before destructuring
+  - Prevents runtime errors if called with invalid arguments
+  - Gracefully handles `null`, `undefined`, or non-object values
+  
+- **Browser Compatibility**: Added CSS.escape polyfill in `utils.js`
+  - Full W3C spec-compliant implementation for older browsers
+  - Supports browsers without native CSS.escape (IE, older Safari)
+  - Handles edge cases: NULL characters, leading digits, special characters
+  - Safe escaping for dynamic selector generation
 
 ---
 

--- a/lagerbestand/css/tables.css
+++ b/lagerbestand/css/tables.css
@@ -26,6 +26,16 @@ tbody tr:hover {
     background-color: var(--bg-color);
 }
 
+/* Highlighted row for edited materials */
+.highlighted-row {
+    transition: background-color 0.3s ease;
+    background-color: var(--primary-color-light, #e3f2fd) !important;
+}
+
+body.dark-mode .highlighted-row {
+    background-color: rgba(33, 150, 243, 0.2) !important;
+}
+
 .alert-row {
     background-color: #fee2e2;
 }

--- a/lagerbestand/js/ui-manager.js
+++ b/lagerbestand/js/ui-manager.js
@@ -938,6 +938,13 @@ class UIManager {
         }
 
         if (this.dataManager.deleteMaterial(code)) {
+            // Remove from selected items if it was selected
+            if (this.selectedItems && this.selectedItems.has(code)) {
+                this.selectedItems.delete(code);
+                this.updateBulkActionsToolbar();
+                this.updateSelectAllCheckbox();
+            }
+            
             // Preserve state when deleting (but don't highlight anything)
             this.renderMaterialsList({ preserveState: true });
             

--- a/lagerbestand/js/utils.js
+++ b/lagerbestand/js/utils.js
@@ -9,6 +9,80 @@
  */
 
 /**
+ * CSS.escape polyfill for older browsers
+ * Spec: https://drafts.csswg.org/cssom/#the-css.escape%28%29-method
+ */
+if (!window.CSS || !CSS.escape) {
+    if (!window.CSS) window.CSS = {};
+    
+    CSS.escape = function(value) {
+        if (arguments.length === 0) {
+            throw new TypeError('`CSS.escape` requires an argument.');
+        }
+        var string = String(value);
+        var length = string.length;
+        var index = -1;
+        var codeUnit;
+        var result = '';
+        var firstCodeUnit = string.charCodeAt(0);
+        while (++index < length) {
+            codeUnit = string.charCodeAt(index);
+            // Note: there's no need to special-case astral symbols, surrogate
+            // pairs, or lone surrogates.
+
+            // If the character is NULL (U+0000), then throw an
+            // `InvalidCharacterError` exception and terminate these steps.
+            if (codeUnit === 0x0000) {
+                throw new Error('Invalid character: the input contains U+0000.');
+            }
+
+            if (
+                // If the character is in the range [\1-\1F] (U+0001 to U+001F) or is
+                // U+007F, […]
+                (codeUnit >= 0x0001 && codeUnit <= 0x001F) || codeUnit === 0x007F ||
+                // If the character is the first character and is in the range [0-9]
+                // (U+0030 to U+0039), […]
+                (index === 0 && codeUnit >= 0x0030 && codeUnit <= 0x0039) ||
+                // If the character is the second character and is in the range [0-9]
+                // (U+0030 to U+0039) and the first character is a `-` (U+002D), […]
+                (
+                    index === 1 &&
+                    codeUnit >= 0x0030 && codeUnit <= 0x0039 &&
+                    firstCodeUnit === 0x002D
+                )
+            ) {
+                // https://drafts.csswg.org/cssom/#escape-a-character-as-code-point
+                result += '\\' + codeUnit.toString(16) + ' ';
+                continue;
+            }
+
+            // If the character is not handled by one of the above rules and is
+            // greater than or equal to U+0080, is `-` (U+002D) or `_` (U+005F), or
+            // is in one of the ranges [0-9] (U+0030 to U+0039), [A-Z] (U+0041 to
+            // U+005A), or [a-z] (U+0061 to U+007A), […]
+            if (
+                codeUnit >= 0x0080 ||
+                codeUnit === 0x002D ||
+                codeUnit === 0x005F ||
+                codeUnit >= 0x0030 && codeUnit <= 0x0039 ||
+                codeUnit >= 0x0041 && codeUnit <= 0x005A ||
+                codeUnit >= 0x0061 && codeUnit <= 0x007A
+            ) {
+                // the character itself
+                result += string.charAt(index);
+                continue;
+            }
+
+            // Otherwise, the escaped character.
+            // https://drafts.csswg.org/cssom/#escape-a-character
+            result += '\\' + string.charAt(index);
+
+        }
+        return result;
+    };
+}
+
+/**
  * XSS Protection and Sanitization Utilities
  */
 class SecurityUtils {


### PR DESCRIPTION
This pull request focuses on improving the user experience when managing materials in the list by preserving the table state across edits, deletions, and bulk operations. The main enhancement ensures that actions such as editing, deleting, undo/redo, and bulk updates no longer reset the materials list to its initial state, maintaining scroll position, page, search, sorting, and selections for workflow continuity.

**Materials List State Preservation**

* Added `saveMaterialsTableState()` and `restoreMaterialsTableState()` methods in `js/tab-materials.js` to capture and restore table state, including page number, search term, sorting, selections, and scroll position. Also supports optional highlighting and smooth scrolling to edited materials.
* Updated `renderMaterialsList()` to accept an `options` parameter (`preserveState`, `highlightMaterialCode`) and utilize the new state preservation logic. [[1]](diffhunk://#diff-888f20641424a35db21a3541abfa7ab0bfb42bc55c07edb30679aeb26ef0212fR616-R730) [[2]](diffhunk://#diff-888f20641424a35db21a3541abfa7ab0bfb42bc55c07edb30679aeb26ef0212fR795-R799)
* Modified undo/redo, group deletion, bulk edit, and bulk delete operations in `js/tab-materials.js` to call `renderMaterialsList()` with state preservation enabled, ensuring table state continuity after these actions. [[1]](diffhunk://#diff-888f20641424a35db21a3541abfa7ab0bfb42bc55c07edb30679aeb26ef0212fL898-R1013) [[2]](diffhunk://#diff-888f20641424a35db21a3541abfa7ab0bfb42bc55c07edb30679aeb26ef0212fL910-R1025) [[3]](diffhunk://#diff-888f20641424a35db21a3541abfa7ab0bfb42bc55c07edb30679aeb26ef0212fL1576-R1691) [[4]](diffhunk://#diff-888f20641424a35db21a3541abfa7ab0bfb42bc55c07edb30679aeb26ef0212fL2055-R2170) [[5]](diffhunk://#diff-888f20641424a35db21a3541abfa7ab0bfb42bc55c07edb30679aeb26ef0212fL2101-R2216)

**Single Material Edit/Delete**

* Updated `saveMaterialModal()` and `deleteMaterial()` in `js/ui-manager.js` to preserve table state and optionally highlight the edited material after save, improving feedback and navigation for users. [[1]](diffhunk://#diff-3ad70d19e4d6886b4381c17dca918a30ce68eb2f403c71d9aea5e2eb3f0d77ebL879-R883) [[2]](diffhunk://#diff-3ad70d19e4d6886b4381c17dca918a30ce68eb2f403c71d9aea5e2eb3f0d77ebL938-R942)

**Documentation**

* Added a detailed changelog entry in `CHANGELOG.md` describing the new state preservation feature and affected files.Materials list now retains scroll position, page, search, sorting, and selections after editing, deleting, undo/redo, and bulk operations. Added state save/restore methods and optional row highlighting for improved workflow continuity. Changes affect tab-materials.js and ui-manager.js.

Closes #48

## Summary by Sourcery

Preserve the materials list DataTable state—page, sorting, search, selections, and scroll position—across individual edits, deletions, bulk actions, and undo/redo by adding state save/restore functionality and extending renderMaterialsList with preservation and highlighting options.

Enhancements:
- Add saveMaterialsTableState and restoreMaterialsTableState methods to capture and reapply DataTable state
- Extend renderMaterialsList to accept preserveState and highlightMaterialCode options
- Update edit, delete, bulk operations, undo/redo, and group deletion to preserve table state and optionally highlight updated rows

Documentation:
- Document state preservation feature in CHANGELOG